### PR TITLE
bump awscala version to 0.8.4 that fixes null pointer exception

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ crossScalaVersions := Seq("2.11.12", scalaVersion.value)
 
 libraryDependencies ++= Seq(
   "org.scala-lang"     %  "scala-reflect" % scalaVersion.value,
-  "com.github.seratch" %% "awscala"       % "0.8.2",
+  "com.github.seratch" %% "awscala"       % "0.8.4",
   "org.scalatest"      %% "scalatest"     % "3.0.7" % "test"
 )
 


### PR DESCRIPTION
This PR is to updated `awscala` dependency to newest version - 0.8.4
I've been getting following errors when trying to `put` records into DB.

```
java.lang.NullPointerException
        at awscala.dynamodbv2.BillingModeSummary$.apply(TableMeta.scala:103)
        at awscala.dynamodbv2.TableMeta$.apply(TableMeta.scala:21)
        at awscala.dynamodbv2.DynamoDB.describe(DynamoDB.scala:56)
        at awscala.dynamodbv2.DynamoDB.describe$(DynamoDB.scala:55)
        at awscala.dynamodbv2.DynamoDBClient.describe(DynamoDB.scala:368)
        at awscala.dynamodbv2.DynamoDB.table(DynamoDB.scala:64)
        at awscala.dynamodbv2.DynamoDB.table$(DynamoDB.scala:64)
        at awscala.dynamodbv2.DynamoDBClient.table(DynamoDB.scala:368)
```

In version 0.8.4:
`billingModeSummary = BillingModeSummary(t.getBillingModeSummary))`

was changes to 

`billingModeSummary = Option(t.getBillingModeSummary).map(BillingModeSummary.apply))`